### PR TITLE
Update README with a link to the hashing documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ You can configure this through the following environment variables when running 
  * POSTFIXADMIN_ENCRYPT=... - database password encryption (e.g. md5crypt, SHA512-CRYPT)
  * POSTFIXADMIN\_SETUP\_PASSWORD=... - generated from setup.php or `php -r "echo password_hash('mysecretpassword', PASSWORD_DEFAULT);"`
 
-Note: An SQLite database is probably not recommended for production use, but is a quick and easy way to try out the software without dependencies. 
+Note: An SQLite database is probably not recommended for production use, but is a quick and easy way to try out the software without dependencies.
+
+Note2: For details about database password encryption please refer to the [postfixadmin hashing documentation](https://github.com/postfixadmin/postfixadmin/blob/postfixadmin_3.3/DOCUMENTS/HASHING.md)
 
 You can also set the postfix host and port.
 


### PR DESCRIPTION
As suggested, a note in the readme about the password hashing options/capabilities of postfixadmin.

Fixes #62, IMO.